### PR TITLE
Used ast module to compile menu rules matching code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+__pycache__
 build/
 _build/
 dist/

--- a/test/test-menu-rules.py
+++ b/test/test-menu-rules.py
@@ -2,6 +2,7 @@ import xml.dom.minidom
 import unittest
 
 from xdg.Menu import Rule
+from xdg.Menu import __parseRule as parseRule
 
 
 _tests = [
@@ -162,10 +163,10 @@ class RulesTest(unittest.TestCase):
     def test_rule_from_node(self):
         for i, test in enumerate(_tests):
             root = xml.dom.minidom.parseString(test['doc']).childNodes[0]
-            rule = Rule.fromNode(root)
+            rule = parseRule(root)
             for j, data in enumerate(test['data']):
                 menuentry = MockMenuEntry(data[0], data[1])
-                result = eval(rule.Rule)
+                result = eval(rule.code)
                 message = "Error in test %s with result set %s: got %s, expected %s"
                 assert result == data[2], message % (i, j, result, data[2])
 
@@ -175,8 +176,8 @@ class RulesTest(unittest.TestCase):
             ('barfoo.desktop', 'foobar.desktop', False)
         ]
         for i, test in enumerate(tests):
-            rule = Rule.fromFilename('Include', test[0])
+            rule = Rule.fromFilename(Rule.TYPE_INCLUDE, test[0])
             menuentry = MockMenuEntry(test[1], [])
-            result = eval(rule.Rule)
+            result = eval(rule.code)
             message = "Error with result set %s: got %s, expected %s"
             assert result == test[2], message % (i, result, test[2])


### PR DESCRIPTION
Kudos for your awesome documentation on the ast module.
I've been able to port my previous implementation in just about the time needed to understand the docs !

I've made a little benchmark just to show the improvements.
I ran each of the implementations 10 times against three different menu files: a small one (LXDE's - 4Ko), a medium one (hand-rolled - 7Ko) and a big one (KDE4's - 11Ko). For each implementation, I kept only the best scores.
Results are in seconds

```
+---------------------------+-------------------+-----------------+-------------------+
|                           | lxde-applications | my-applications | kde4-applications |
+---------------------------+-------------------+-----------------+-------------------+
| takluyver/pyxdg-master    |      0.080        |      0.090      |      0.190        |
+---------------------------+-------------------+-----------------+-------------------+
| ju1ius/pyxdg-rules-noeval |      0.060        |      0.070      |      0.090        |
+---------------------------+-------------------+-----------------+-------------------+
| ju1ius/pyxdg-rules-ast    |      0.050        |      0.060      |      0.070        |
+---------------------------+-------------------+-----------------+-------------------+
```
