### PR TITLE
Bugfix AttributeError: type is not stored in attribute but calculated by method.

### DIFF
--- a/xdg/Menu.py
+++ b/xdg/Menu.py
@@ -994,8 +994,8 @@ class XMLMenuBuilder(object):
                     menuentry = MenuEntry(directory, dir)
                     if not menu.Directory:
                         menu.Directory = menuentry
-                    elif menuentry.Type == MenuEntry.TYPE_SYSTEM:
-                        if menu.Directory.Type == MenuEntry.TYPE_USER:
+                    elif menuentry.getType() == MenuEntry.TYPE_SYSTEM:
+                        if menu.Directory.getType() == MenuEntry.TYPE_USER:
                             menu.Directory.Original = menuentry
             if menu.Directory:
                 break


### PR DESCRIPTION
The error is exhibited easily by applying xdg.Menu.parse to a non-trivial menu file.

The correction seems straight-forward.