### PR TITLE
BaseDirectory: fix race condition for os.makedirs()

### DIFF
--- a/xdg/BaseDirectory.py
+++ b/xdg/BaseDirectory.py
@@ -54,8 +54,7 @@ def save_config_path(*resource):
     resource = os.path.join(*resource)
     assert not resource.startswith('/')
     path = os.path.join(xdg_config_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path, 0o700)
+    os.makedirs(path, 0o700, exist_ok=True)
     return path
 
 def save_data_path(*resource):
@@ -66,8 +65,7 @@ def save_data_path(*resource):
     resource = os.path.join(*resource)
     assert not resource.startswith('/')
     path = os.path.join(xdg_data_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 
 def save_cache_path(*resource):
@@ -77,8 +75,7 @@ def save_cache_path(*resource):
     resource = os.path.join(*resource)
     assert not resource.startswith('/')
     path = os.path.join(xdg_cache_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 
 def load_config_paths(*resource):


### PR DESCRIPTION
In the case of parallel usage, there is race between when the
directory is checked and created.  To prevent this race, use
exist_ok=True which is supported in python 3.2+.

https://docs.python.org/3/library/os.html#os.makedirs

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>