### PR TITLE
Support RecentFiles on windows via portalocker...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,8 @@ setup( name = "pyxdg",
             "Programming Language :: Python :: 3",
             "Topic :: Desktop Environment",
        ],
+       install_requires=[
+           "portalocker ; platform_system=='Windows'",
+       ],
 )
 


### PR DESCRIPTION
without adding new dependencies on other platforms

----

So this pull request would be a bit cleaner if we just always used portalocker instead of using `fcntl`, but I think there's something to be said about not requiring anything outside the standard library on the primary target platform (linux).

While XDG isn't really a thing on Windows and Mac, the default paths (if none of the XDG environment variables are set) do work, even if they're a bit out of place. And if one declares a few of the `XRD_` variables, an app using the XDG spec can also comply with MS's and Apple's preferred locations, too. Porting apps is a bit easier if this library doesn't crash.