### PR TITLE
Initial atheris fuzzing integration

### DIFF
--- a/test/fuzz_menu.py
+++ b/test/fuzz_menu.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import atheris
+
+with atheris.instrument_imports(enable_loader_override=False):
+    import xdg.Menu
+    from xdg.Exceptions import ParsingError
+
+@atheris.instrument_func
+def TestOneInput(input_bytes):
+    # We need to make the file an absolute path
+    testfile_path = os.path.join(os.getcwd(), "test.menu")
+    with open(testfile_path, "wb") as f:
+	f.write(input_bytes)
+    try:
+	xdg.Menu.parse(filename = testfile_path)
+    except ParsingError:
+	None
+    os.remove(testfile_path)
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Hi,

I was wondering if you would like to integrate continuous fuzzing of pyxdg by way of OSS-Fuzz? In this PR https://github.com/google/oss-fuzz/pull/7514 I do exactly that, namely created the necessary logic from an OSS-Fuzz perspective.

This includes developing initial fuzzers as well as integrating into OSS-Fuzz, however, it is preferable to have the fuzzers upstream so I included it in this PR - if you are happy with having the fuzzers here then I will remove them from the OSS-Fuzz repository.

Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

If you would like to integrate, the only thing I need is as list of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. Notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.