### PR TITLE
Drop support for Python 2; prevent errors due to race condition with existing directories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "2.7", "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,85 @@
 *.pyc
 __pycache__
-build/
 _build/
-*.egg-info/
+
 dist/
 MANIFEST
-.coverage
 cover/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+.eggs
+parts
+bin
+var
+sdist
+wheelhouse
+develop-eggs
+.installed.cfg
+lib
+lib64
+venv*/
+pyvenv*/
+pip-wheel-metadata/
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+.coverage.*
+.pytest_cache/
+nosetests.xml
+coverage.xml
+htmlcov
+
+# Translations
+*.mo
+
+# Buildout
+.mr.developer.cfg
+
+# IDE project files
+.project
+.pydevproject
+.idea
+.vscode
+*.iml
+*.komodoproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+
+.DS_Store
+*~
+.*.sw[po]
+.build
+.ve
+.env
+.cache
+.pytest
+.benchmarks
+.bootstrap
+.appveyor.token
+*.bak
+
+# Mypy Cache
+.mypy_cache/
+.python-version
+scratch.py
+
+# IntelliJ
+.idea

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Version 0.29 (June 2022)
+
+    * Drop support for Python 2 (only Python 3.2 and greater are supported)
+    * BaseDirectory: Suppress error caused by a race condition when directories already exist.
+
 Version 0.28 (June 2022)
 
     * BaseDirectory: Add support for $XDG_STATE_DIR

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,18 @@
 
 from setuptools import setup
 
-setup( name = "pyxdg",
-       version = "0.28",
-       description = "PyXDG contains implementations of freedesktop.org standards in python.",
-       maintainer = "Freedesktop.org",
-       maintainer_email = "xdg@lists.freedesktop.org",
-       url = "http://freedesktop.org/wiki/Software/pyxdg",
-       packages = ['xdg'],
-       classifiers = [
-            "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
-            "Topic :: Desktop Environment",
-       ],
+setup(
+    name="pyxdg",
+    version="0.29",
+    description="PyXDG contains implementations of freedesktop.org standards in python.",
+    maintainer="Freedesktop.org",
+    maintainer_email="xdg@lists.freedesktop.org",
+    url="http://freedesktop.org/wiki/Software/pyxdg",
+    packages=["xdg"],
+    python_requires=">=3.2",
+    classifiers=[
+        "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
+        "Programming Language :: Python :: 3",
+        "Topic :: Desktop Environment",
+    ],
 )
-

--- a/xdg/BaseDirectory.py
+++ b/xdg/BaseDirectory.py
@@ -49,51 +49,44 @@ xdg_state_home = os.environ.get('XDG_STATE_HOME') or \
 xdg_data_dirs = [x for x in xdg_data_dirs if x]
 xdg_config_dirs = [x for x in xdg_config_dirs if x]
 
+
+def _ensure_path(base, resource):
+    resource = os.path.join(*resource)
+    assert not resource.startswith('/')
+    path = os.path.join(base, resource)
+    os.makedirs(path, 0o700, exist_ok=True)
+    return path
+
+
 def save_config_path(*resource):
     """Ensure ``$XDG_CONFIG_HOME/<resource>/`` exists, and return its path.
     'resource' should normally be the name of your application. Use this
     when saving configuration settings.
     """
-    resource = os.path.join(*resource)
-    assert not resource.startswith('/')
-    path = os.path.join(xdg_config_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path, 0o700)
-    return path
+    return _ensure_path(xdg_config_home, resource)
+
 
 def save_data_path(*resource):
     """Ensure ``$XDG_DATA_HOME/<resource>/`` exists, and return its path.
     'resource' should normally be the name of your application or a shared
     resource. Use this when saving or updating application data.
     """
-    resource = os.path.join(*resource)
-    assert not resource.startswith('/')
-    path = os.path.join(xdg_data_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    return path
+    return _ensure_path(xdg_data_home, resource)
+
 
 def save_cache_path(*resource):
     """Ensure ``$XDG_CACHE_HOME/<resource>/`` exists, and return its path.
     'resource' should normally be the name of your application or a shared
     resource."""
-    resource = os.path.join(*resource)
-    assert not resource.startswith('/')
-    path = os.path.join(xdg_cache_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    return path
+    return _ensure_path(xdg_cache_home, resource)
+
 
 def save_state_path(*resource):
     """Ensure ``$XDG_STATE_HOME/<resource>/`` exists, and return its path.
     'resource' should normally be the name of your application or a shared
     resource."""
-    resource = os.path.join(*resource)
-    assert not resource.startswith('/')
-    path = os.path.join(xdg_state_home, resource)
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    return path
+    return _ensure_path(xdg_state_home, resource)
+
 
 def load_config_paths(*resource):
     """Returns an iterator which gives each directory named 'resource' in the
@@ -105,12 +98,14 @@ def load_config_paths(*resource):
         path = os.path.join(config_dir, resource)
         if os.path.exists(path): yield path
 
+
 def load_first_config(*resource):
     """Returns the first result from load_config_paths, or None if there is nothing
     to load."""
     for x in load_config_paths(*resource):
         return x
     return None
+
 
 def load_data_paths(*resource):
     """Returns an iterator which gives each directory named 'resource' in the
@@ -120,6 +115,7 @@ def load_data_paths(*resource):
     for data_dir in xdg_data_dirs:
         path = os.path.join(data_dir, resource)
         if os.path.exists(path): yield path
+
 
 def get_runtime_dir(strict=True):
     """Returns the value of $XDG_RUNTIME_DIR, a directory path.


### PR DESCRIPTION
Per abandoned-looking https://github.com/takluyver/pyxdg/pull/15, the easiest way to suppress race conditions regarding existing directories is to use the Python 3.2+ `exist_ok` flag.

This PR:
- Uses that flag.
- Drops support for Python 2; Py3.2 or greater is now required.
- Updates gitignore to be the GitHub standard.