### PR TITLE
Add API matching srstevenson/xdg in xdg namespace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "2.7", "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup( name = "pyxdg",
        packages = ['xdg'],
        classifiers = [
             "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
             "Topic :: Desktop Environment",
        ],

--- a/xdg/__init__.py
+++ b/xdg/__init__.py
@@ -1,3 +1,69 @@
-__all__ = [ "BaseDirectory", "DesktopEntry", "Menu", "Exceptions", "IniFile", "IconTheme", "Locale", "Config", "Mime", "RecentFiles", "MenuEditor" ]
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from xdg import BaseDirectory
+
+__all__ = [
+    "BaseDirectory",
+    "DesktopEntry",
+    "Menu",
+    "Exceptions",
+    "IniFile",
+    "IconTheme",
+    "Locale",
+    "Config",
+    "Mime",
+    "RecentFiles",
+    "MenuEditor",
+]
 
 __version__ = "0.28"
+
+
+def xdg_cache_home() -> Path:
+    """Return a Path corresponding to XDG_CACHE_HOME."""
+    return Path(BaseDirectory.xdg_cache_home)
+
+
+def xdg_config_dirs() -> List[Path]:
+    """Return a list of Paths corresponding to XDG_CONFIG_DIRS."""
+    try:
+        return [Path(path) for path in os.environ["XDG_CONFIG_DIRS"].split(":")]
+    except KeyError:
+        return [Path("/etc/xdg")]
+
+
+def xdg_config_home() -> Path:
+    """Return a Path corresponding to XDG_CONFIG_HOME."""
+    return Path(BaseDirectory.xdg_config_home)
+
+
+def xdg_data_dirs() -> List[Path]:
+    """Return a list of Paths corresponding to XDG_DATA_DIRS."""
+    try:
+        return [Path(path) for path in os.environ["XDG_DATA_DIRS"].split(":")]
+    except KeyError:
+        return [Path("/usr/local/share"), Path("/usr/share")]
+
+
+def xdg_data_home() -> Path:
+    """Return a Path corresponding to XDG_DATA_HOME."""
+    return Path(BaseDirectory.xdg_data_home)
+
+
+def xdg_runtime_dir() -> Optional[Path]:
+    """Return a Path corresponding to XDG_RUNTIME_DIR.
+
+    If the XDG_RUNTIME_DIR environment variable is not set, None will be
+    returned as per the specification.
+    """
+    try:
+        return Path(BaseDirectory.get_runtime_dir())
+    except KeyError:
+        return None
+
+
+def xdg_state_home() -> Path:
+    """Return a Path corresponding to XDG_STATE_HOME."""
+    return Path(BaseDirectory.xdg_state_home)


### PR DESCRIPTION
This adds the API of [srstevenson/xdg](https://github.com/srstevenson/xdg) to PyXDG in the `xdg` namespace (which necessitates dropping support for Python 2.7), as discussed with @takluyver in https://github.com/srstevenson/xdg/issues/75.