### PR TITLE
`DirectorySizeDistance` must return an `int`

### DIFF
--- a/xdg/IconTheme.py
+++ b/xdg/IconTheme.py
@@ -443,3 +443,4 @@ def DirectorySizeDistance(subdir, iconsize, theme):
         elif iconsize > Size + Threshold:
             return iconsize - MaxSize
         return 0
+    return 2**31


### PR DESCRIPTION
Otherwise these two lines:
https://github.com/takluyver/pyxdg/blob/1d23e483ae869ee9532aca43b133cc43f63626a3/xdg/IconTheme.py#L404 cause a `TypeError: '<' not supported between instances of 'NoneType' and 'int'`

Returning `2**31` prevents this issue and ensures this unexpected theme `Type` is not used.