### PR TITLE
General update for current Python

### DIFF
--- a/test/test_basedirectory.py
+++ b/test/test_basedirectory.py
@@ -9,7 +9,10 @@ import stat
 try:
     reload
 except NameError:
-    from imp import reload
+    try:
+        from imp import reload
+    except ModuleNotFoundError:
+        from importlib import reload
 
 class BaseDirectoryTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_mime.py
+++ b/test/test_mime.py
@@ -1,7 +1,16 @@
 from xdg import Mime
+import xdg.BaseDirectory
 import unittest
-import os.path
+import os
 import tempfile, shutil
+
+try:
+    reload
+except NameError:
+    try:
+        from imp import reload
+    except ModuleNotFoundError:
+        from importlib import reload
 
 import resources
 
@@ -402,3 +411,50 @@ class GlobsParsingTest(MimeTestBase):
         self.assertEqual(ag[_l('text', 'x-c++src')], set([(50, '*.C', ('cs',))]) )
         self.assertEqual(ag[_l('text', 'x-readme')], set([(20, 'RDME', ('cs',))]) )
         assert _l('text', 'x-python') not in ag, ag
+
+
+def test_install_mime_info(tmp_path):
+    # 1. Redirect to temporary XDG_DATA_HOME
+    # 2. Install test MIME info
+    # 3. Confirm it is working as intended
+    # 4. Restore previous XDG_DATA_HOME and reload MIME database
+    test_definition = """<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+<mime-type type="application/x.xdg-mime-selftest">
+  <comment>Canary file type to test database installation effect</comment>
+  <glob pattern="*.xdg-mime-selftest"/>
+</mime-type>
+</mime-info>
+"""
+    old_xdg_data_home = os.environ.get('XDG_DATA_HOME')
+    try:
+        workdir = tmp_path / 'localshare'
+        os.environ['XDG_DATA_HOME'] = str(workdir)
+        # Make the new base directory active by reloading the module
+        reload(xdg.BaseDirectory)
+
+        package_file = tmp_path / 'xdg-mime-selftest.xml'
+        package_file.write_text(test_definition)
+        Mime.install_mime_info(application='xdg-mime-selftest-foo', package_file=package_file)
+
+        installed = workdir / 'mime' / 'packages' / 'xdg-mime-selftest-foo.xml'
+        # File was installed under the correct name to the correct location
+        assert installed.exists()
+        # ...with the correct content
+        assert installed.read_text() == test_definition
+
+        # Does not need to exist when matching by name
+        res = Mime.get_type_by_name('/tmp/whatever.xdg-mime-selftest')
+        assert res.media == 'application'
+        assert res.subtype == 'x.xdg-mime-selftest'
+    finally:
+        if old_xdg_data_home is None:
+            del os.environ['XDG_DATA_HOME']
+        else:
+            os.environ['XDG_DATA_HOME'] = old_xdg_data_home
+        reload(xdg.BaseDirectory)
+        # Force reload to remove entry
+        Mime._cache_database()
+    # Make sure we have properly deactivated the temporary MIME
+    res = Mime.get_type_by_name('/tmp/whatever.xdg-mime-selftest')
+    assert res is None

--- a/xdg/Menu.py
+++ b/xdg/Menu.py
@@ -411,7 +411,7 @@ class Rule:
     def fromFilename(cls, type, filename):
         tree = ast.Expression(
             body=ast.Compare(
-                left=ast.Str(filename),
+                left=ast.Constant(filename),
                 ops=[ast.Eq()],
                 comparators=[ast.Attribute(
                     value=ast.Name(id='menuentry', ctx=ast.Load()),
@@ -419,7 +419,6 @@ class Rule:
                     ctx=ast.Load()
                 )]
             ),
-            lineno=1, col_offset=0
         )
         ast.fix_missing_locations(tree)
         rule = Rule(type, tree)
@@ -763,12 +762,10 @@ class XMLMenuBuilder(object):
 
     def parse_rule(self, node):
         type = Rule.TYPE_INCLUDE if node.tag == 'Include' else Rule.TYPE_EXCLUDE
-        tree = ast.Expression(lineno=1, col_offset=0)
         expr = self.parse_bool_op(node, ast.Or())
-        if expr:
-            tree.body = expr
-        else:
-            tree.body = _ast_const('False')
+        if not expr:
+            expr = _ast_const('False')
+        tree = ast.Expression(expr)
         ast.fix_missing_locations(tree)
         return Rule(type, tree)
 
@@ -799,7 +796,7 @@ class XMLMenuBuilder(object):
         elif tag == 'Category':
             category = node.text
             return ast.Compare(
-                left=ast.Str(category),
+                left=ast.Constant(category),
                 ops=[ast.In()],
                 comparators=[ast.Attribute(
                     value=ast.Name(id='menuentry', ctx=ast.Load()),
@@ -810,7 +807,7 @@ class XMLMenuBuilder(object):
         elif tag == 'Filename':
             filename = node.text
             return ast.Compare(
-                left=ast.Str(filename),
+                left=ast.Constant(filename),
                 ops=[ast.Eq()],
                 comparators=[ast.Attribute(
                     value=ast.Name(id='menuentry', ctx=ast.Load()),

--- a/xdg/Mime.py
+++ b/xdg/Mime.py
@@ -24,6 +24,7 @@ import re
 import stat
 import sys
 import fnmatch
+import subprocess
 
 from xdg import BaseDirectory
 import xdg.Locale
@@ -777,8 +778,17 @@ def install_mime_info(application, package_file):
 
     # Update the database...
     command = 'update-mime-database'
-    if os.spawnlp(os.P_WAIT, command, command, BaseDirectory.save_data_path('mime')):
+    directory = BaseDirectory.save_data_path('mime')
+    res = subprocess.run(
+        (command, directory),
+        check=False,
+        capture_output=True
+    )
+    if res.returncode != 0:
         os.unlink(new_file)
+        output = res.stderr.decode('utf-8') + '\n' + res.stdout.decode('utf-8')
         raise Exception("The '%s' command returned an error code!\n" \
+                  "Output '%s' \n" \
                   "Make sure you have the freedesktop.org shared MIME package:\n" \
-                  "http://standards.freedesktop.org/shared-mime-info/" % command)
+                  "http://standards.freedesktop.org/shared-mime-info/" % (command, output)
+        )


### PR DESCRIPTION
* Previous method to run update-mime-database threw warnings about thread safety of `fork()`. Ported to `subprocess` module, the currently recommended method.
* Add test case for installing mime info, was missing before
* Handle deprecations in `ast`. Unclear what purpose `lineno` and `col_offset` served.
* Handle move of `reload()` from `imp` to `importlib`

The tests were already broken in Python 3.14, and the warning messages indicated that `xdg` will stop working with Python 3.15 without these changes.